### PR TITLE
PLT-15594: Include Syllabus in Export Process

### DIFF
--- a/lib/multi_version_common_cartridge/resources/canvas_course_settings.rb
+++ b/lib/multi_version_common_cartridge/resources/canvas_course_settings.rb
@@ -19,7 +19,7 @@ module MultiVersionCommonCartridge
     module CanvasCourseSettings
 
       class CanvasCourseSettings < MultiVersionCommonCartridge::Resources::Resource
-        attr_accessor :image_url, :group_weighting_scheme, :assignment_groups, :modules, :href
+        attr_accessor :image_url, :group_weighting_scheme, :assignment_groups, :modules, :href, :syllabus_body
 
         def initialize; end
 

--- a/lib/multi_version_common_cartridge/version.rb
+++ b/lib/multi_version_common_cartridge/version.rb
@@ -15,5 +15,5 @@
 # along with multi_version_common_cartridge.  If not, see <http://www.gnu.org/licenses/>.
 
 module MultiVersionCommonCartridge
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
@@ -35,13 +35,14 @@ module MultiVersionCommonCartridge
       end
 
       def files
-        [
+        file_list = [
           File.join(resource_path, COURSE_SETTINGS_FILENAME),
           File.join(resource_path, CANVAS_EXPORT_FILENAME),
           File.join(resource_path, ASSIGNMENT_GROUPS_FILENAME),
-          File.join(resource_path, MODULE_META_FILENAME),
-          File.join(resource_path, SYLLABUS_FILENAME)
+          File.join(resource_path, MODULE_META_FILENAME)
         ]
+        file_list << File.join(resource_path, SYLLABUS_FILENAME) if resource.syllabus_body
+        file_list
       end
 
       def create_files(out_dir)

--- a/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
@@ -80,8 +80,10 @@ module MultiVersionCommonCartridge
           file.write(module_meta_doc.to_xml)
         end
 
-        File.open(File.join(out_dir, resource_path, SYLLABUS_FILENAME), 'w') do |file|
-          file.write(syllabus_contents)
+        if resource.syllabus_body
+          File.open(File.join(out_dir, resource_path, SYLLABUS_FILENAME), 'w') do |file|
+            file.write(syllabus_contents)
+          end
         end
       end
 

--- a/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
@@ -28,6 +28,7 @@ module MultiVersionCommonCartridge
       CANVAS_EXPORT_FILENAME = 'canvas_export.txt'.freeze
       ASSIGNMENT_GROUPS_FILENAME = 'assignment_groups.xml'.freeze
       MODULE_META_FILENAME = 'module_meta.xml'.freeze
+      SYLLABUS_FILENAME = 'syllabus.html'.freeze
 
       def type
         'webcontent'
@@ -39,6 +40,7 @@ module MultiVersionCommonCartridge
           File.join(resource_path, CANVAS_EXPORT_FILENAME),
           File.join(resource_path, ASSIGNMENT_GROUPS_FILENAME),
           File.join(resource_path, MODULE_META_FILENAME),
+          File.join(resource_path, SYLLABUS_FILENAME)
         ]
       end
 
@@ -77,6 +79,14 @@ module MultiVersionCommonCartridge
         File.open(File.join(out_dir, resource_path, MODULE_META_FILENAME), 'w') do |file|
           file.write(module_meta_doc.to_xml)
         end
+
+        File.open(File.join(out_dir, resource_path, SYLLABUS_FILENAME), 'w') do |file|
+          file.write(syllabus_contents)
+        end
+      end
+
+      def syllabus_contents
+        "<html><body><h1>Syllabus</h1>#{resource.syllabus_body}</body></html>"
       end
 
       def course_settings_element

--- a/spec/lib/writers/canvas_course_settings_writer_spec.rb
+++ b/spec/lib/writers/canvas_course_settings_writer_spec.rb
@@ -225,5 +225,32 @@ describe MultiVersionCommonCartridge::Writers::CanvasCourseSettingsWriter do
         expect(File.read(assignment_groups_filename)).to eq(xml_content)
       end
     end
+
+    context 'when a syllabus body is present' do
+      let(:syllabus_content) { "<html><body><h1>Syllabus</h1>#{syllabus_body}</body></html>" }
+      let(:syllabus_body) { SecureRandom.uuid }
+
+      before { course_settings.syllabus_body = syllabus_body }
+
+      it 'creates an html file with the syllabus element' do
+        Dir.mktmpdir do |dir|
+          sub_dir = File.join(dir, 'course_settings')
+          syllabus_filename = File.join(sub_dir, 'syllabus.html')
+          course_settings_writer.create_files(dir)
+          expect(File.read(syllabus_filename)).to eq(syllabus_content)
+        end
+      end
+    end
+
+    context 'when syllabus body is not present' do
+      it 'does not create the syllabus file' do
+        Dir.mktmpdir do |dir|
+          sub_dir = File.join(dir, 'course_settings')
+          syllabus_filename = File.join(sub_dir, 'syllabus.html')
+          course_settings_writer.create_files(dir)
+          expect(File.exist?(syllabus_filename)).to be_falsey
+        end
+      end
+    end
   end
 end

--- a/spec/lib/writers/manifest_resources_writer_spec.rb
+++ b/spec/lib/writers/manifest_resources_writer_spec.rb
@@ -131,5 +131,21 @@ describe MultiVersionCommonCartridge::Writers::ManifestResourcesWriter do
       expect(writer.root_resource_element.resources.first.files[3].href).to eq('course_settings/module_meta.xml')
     end
 
+    context 'when syllabus body is set' do
+      let(:syllabus_body) { 'some syllabus body' }
+
+      before do
+        canvas_resource.syllabus_body = syllabus_body
+        writer.finalize
+      end
+
+      it 'has the syllabus file' do
+        expect(writer.root_resource_element.resources.first.files[4].href).to eq('course_settings/syllabus.html')
+      end
+
+      it 'has the files' do
+        expect(writer.root_resource_element.resources.first.files.count).to eq(5)
+      end
+    end
   end
 end

--- a/spec/lib/writers/manifest_resources_writer_spec.rb
+++ b/spec/lib/writers/manifest_resources_writer_spec.rb
@@ -95,41 +95,45 @@ describe MultiVersionCommonCartridge::Writers::ManifestResourcesWriter do
       writer.finalize
     end
 
-    it 'has a resource element for the canvas course settings' do
-      expect(writer.root_resource_element.resources.count).to eq(1)
-    end
-
-    it 'has the identifier' do
-      expect(writer.root_resource_element.resources.first.identifier).to eq(identifier)
-    end
-
-    it 'has the href' do
-      expect(writer.root_resource_element.resources.first.href).to eq(href)
-    end
-
-    it 'has the type' do
-      expect(writer.root_resource_element.resources.first.type).to eq('webcontent')
-    end
-
     it 'has the files' do
       expect(writer.root_resource_element.resources.first.files.count).to eq(4)
     end
 
-    it 'has the course settings file' do
-      expect(writer.root_resource_element.resources.first.files[0].href).to eq('course_settings/course_settings.xml')
+    shared_examples 'base course settings data' do
+      it 'has a resource element for the canvas course settings' do
+        expect(writer.root_resource_element.resources.count).to eq(1)
+      end
+
+      it 'has the identifier' do
+        expect(writer.root_resource_element.resources.first.identifier).to eq(identifier)
+      end
+
+      it 'has the href' do
+        expect(writer.root_resource_element.resources.first.href).to eq(href)
+      end
+
+      it 'has the type' do
+        expect(writer.root_resource_element.resources.first.type).to eq('webcontent')
+      end
+
+      it 'has the course settings file' do
+        expect(writer.root_resource_element.resources.first.files[0].href).to eq('course_settings/course_settings.xml')
+      end
+
+      it 'has the canvas export file' do
+        expect(writer.root_resource_element.resources.first.files[1].href).to eq('course_settings/canvas_export.txt')
+      end
+
+      it 'has the assignment groups file' do
+        expect(writer.root_resource_element.resources.first.files[2].href).to eq('course_settings/assignment_groups.xml')
+      end
+
+      it 'has the module meta file' do
+        expect(writer.root_resource_element.resources.first.files[3].href).to eq('course_settings/module_meta.xml')
+      end
     end
 
-    it 'has the canvas export file' do
-      expect(writer.root_resource_element.resources.first.files[1].href).to eq('course_settings/canvas_export.txt')
-    end
-
-    it 'has the assignment groups file' do
-      expect(writer.root_resource_element.resources.first.files[2].href).to eq('course_settings/assignment_groups.xml')
-    end
-
-    it 'has the module meta file' do
-      expect(writer.root_resource_element.resources.first.files[3].href).to eq('course_settings/module_meta.xml')
-    end
+    include_examples 'base course settings data'
 
     context 'when syllabus body is set' do
       let(:syllabus_body) { 'some syllabus body' }
@@ -146,6 +150,8 @@ describe MultiVersionCommonCartridge::Writers::ManifestResourcesWriter do
       it 'has the files' do
         expect(writer.root_resource_element.resources.first.files.count).to eq(5)
       end
+
+      include_examples 'base course settings data'
     end
   end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-15594-canvas-syllabus)

## Purpose 
<!-- what/why -->

- To be able to export a course syllabus from course builder so that users can easily access and reference the syllabus when needed

## Approach 
<!-- how -->

- Added support for syllabus content in the CanvasCourseSettings class and CanvasCourseSettingsWriter class.
- Updated version to 1.2.0.
- Enhanced file creation logic to include syllabus content if present.
- Added tests to verify the creation of the syllabus file.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

- Unit test and tested canvas cartridge creation within course builder
- Verified the cartridge worked within Canvas

## Screenshots/Video
<!-- show before/after of the change if possible -->
N/A
