### PR TITLE
PLT-16322: Update Basic LTI link writer to use version 1.3 for Canvas

### DIFF
--- a/lib/multi_version_common_cartridge/version.rb
+++ b/lib/multi_version_common_cartridge/version.rb
@@ -15,5 +15,5 @@
 # along with multi_version_common_cartridge.  If not, see <http://www.gnu.org/licenses/>.
 
 module MultiVersionCommonCartridge
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/lib/multi_version_common_cartridge/writers/basic_lti_link_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/basic_lti_link_writer.rb
@@ -152,7 +152,7 @@ module MultiVersionCommonCartridge
       }.freeze
 
       TYPE = {
-        MultiVersionCommonCartridge::CartridgeVersions::CC_1_1_0 => 'imsbasiclti_xmlv1p0',
+        MultiVersionCommonCartridge::CartridgeVersions::CC_1_1_0 => 'imsbasiclti_xmlv1p3',
         MultiVersionCommonCartridge::CartridgeVersions::CC_1_2_0 => 'imsbasiclti_xmlv1p0',
         MultiVersionCommonCartridge::CartridgeVersions::CC_1_3_0 => 'imsbasiclti_xmlv1p3',
         MultiVersionCommonCartridge::CartridgeVersions::THIN_CC_1_2_0 => 'imsbasiclti_xmlv1p0',


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-16322)

## Purpose
Address compatibility issues with the Canvas BLTIConverter by using 1.3 type even though it is a 1.1.0 cartridge.

## Approach
- Change LTI type for CC 1.1.0 from v1.0 to v1.3
- Because canvas will skip adding it as a tool because it doesn't match imsbasiclti_xmlv1p0

See
https://github.com/instructure/canvas-lms/blob/1bf0f5125d0ed958db1edb8115c4e559aa8fed8a/lib/cc/importer/blti_converter.rb#L31
and
https://github.com/instructure/canvas-lms/blob/1bf0f5125d0ed958db1edb8115c4e559aa8fed8a/lib/cc/cc_helper.rb#L49

### Note
This feels wrong because we are actually doing 1.1 cartridges. But it's what our old exporter did.
It almost feels like Canvas expects each and every link to an external tool to have the same URL and we've hacked around this.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm -->
Ran locally.
