### PR TITLE
PLT-15594: Do not auto-include <h1>Syllabus</h1> in syllabus.html for Canvas cartridge exports

### DIFF
--- a/lib/multi_version_common_cartridge/version.rb
+++ b/lib/multi_version_common_cartridge/version.rb
@@ -15,5 +15,5 @@
 # along with multi_version_common_cartridge.  If not, see <http://www.gnu.org/licenses/>.
 
 module MultiVersionCommonCartridge
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end

--- a/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
+++ b/lib/multi_version_common_cartridge/writers/canvas_course_settings_writer.rb
@@ -89,7 +89,7 @@ module MultiVersionCommonCartridge
       end
 
       def syllabus_contents
-        "<html><body><h1>Syllabus</h1>#{resource.syllabus_body}</body></html>"
+        "<html><body>#{resource.syllabus_body}</body></html>"
       end
 
       def course_settings_element

--- a/spec/lib/writers/canvas_course_settings_writer_spec.rb
+++ b/spec/lib/writers/canvas_course_settings_writer_spec.rb
@@ -227,7 +227,7 @@ describe MultiVersionCommonCartridge::Writers::CanvasCourseSettingsWriter do
     end
 
     context 'when a syllabus body is present' do
-      let(:syllabus_content) { "<html><body><h1>Syllabus</h1>#{syllabus_body}</body></html>" }
+      let(:syllabus_content) { "<html><body>#{syllabus_body}</body></html>" }
       let(:syllabus_body) { SecureRandom.uuid }
 
       before { course_settings.syllabus_body = syllabus_body }


### PR DESCRIPTION
Just let the user decide what goes in to the html body